### PR TITLE
feat: add endpoint example

### DIFF
--- a/jest-configs/integration.ts
+++ b/jest-configs/integration.ts
@@ -1,0 +1,6 @@
+import config from '../jest.config';
+
+config.testMatch = ['**/*.test.ts'];
+config.rootDir = '../';
+
+export default config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -538,6 +538,19 @@
       "integrity": "sha512-7QdsX5ZqUEz87twuoKEJe7NHn6OHQsVYQpJcK0disnR0XuVb9FEgQUcsViard9OTNN/fG/nZT63V35vieOwZ4Q==",
       "dev": true
     },
+    "@hapi/hoek": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.1.tgz",
+      "integrity": "sha512-gfta+H8aziZsm8pZa0vj04KO6biEiisppNgA1kbJvFrrWu9Vm7eaUEy76DIxsuTaWvti5fkJVhllWc6ZTE+Mdw=="
+    },
+    "@hapi/topo": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
     "@humanwhocodes/config-array": {
       "version": "0.9.5",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
@@ -862,6 +875,24 @@
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
       }
+    },
+    "@sideway/address": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.3.tgz",
+      "integrity": "sha512-8ncEUtmnTsMmL7z1YPB47kPUq7LpKWJNFPsRzHiIajGC5uXlWGn+AmkYPcHNl8S4tcEGx+cnORnNYaw2wvL+LQ==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "@sideway/formula": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
+      "integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg=="
+    },
+    "@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
     "@sindresorhus/is": {
       "version": "0.14.0",
@@ -3874,6 +3905,18 @@
             "has-flag": "^4.0.0"
           }
         }
+      }
+    },
+    "joi": {
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.6.0.tgz",
+      "integrity": "sha512-OX5dG6DTbcr/kbMFj0KGYxuew69HPcAE3K/sZpEV2nP6e/j/C0HV+HNiBPCASxdx5T7DMoa0s8UeHWMnb6n2zw==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0",
+        "@hapi/topo": "^5.0.0",
+        "@sideway/address": "^4.1.3",
+        "@sideway/formula": "^3.0.0",
+        "@sideway/pinpoint": "^2.0.0"
       }
     },
     "js-tokens": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "typescript": "^4.6.2"
   },
   "dependencies": {
-    "express": "^4.17.3"
+    "express": "^4.17.3",
+    "joi": "^17.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "prepare": "husky install",
     "test": "jest --passWithNoTests --runInBand --no-cache",
     "test:coverage": "npm test -- -c ./jest-configs/coverage.ts",
+    "test:integration": "npm test -- --watch -c ./jest-configs/integration.ts",
     "test:unit": "npm test -- --watch -c ./jest-configs/unit.ts"
   },
   "author": "Vinicius Santiago <viniciussdsilva@gmail.com>",

--- a/src/data/protocols/index.ts
+++ b/src/data/protocols/index.ts
@@ -1,0 +1,1 @@
+export * from './validate-parameters-adapter';

--- a/src/data/protocols/validate-parameters-adapter.ts
+++ b/src/data/protocols/validate-parameters-adapter.ts
@@ -1,3 +1,3 @@
 export interface ValidateParametersAdapter {
-  validate: (input: any) => Promise<void>;
+  validate: (params: any) => Promise<void>;
 }

--- a/src/data/protocols/validate-parameters-adapter.ts
+++ b/src/data/protocols/validate-parameters-adapter.ts
@@ -1,0 +1,3 @@
+export interface ValidateParametersAdapter {
+  validate: (input: any) => Promise<void>;
+}

--- a/src/data/usecases/index.ts
+++ b/src/data/usecases/index.ts
@@ -1,0 +1,1 @@
+export * from './validate-parameters';

--- a/src/data/usecases/validate-parameter.ts
+++ b/src/data/usecases/validate-parameter.ts
@@ -1,0 +1,7 @@
+import { Validation } from '@/domain/usecases';
+
+export class ValidateParameters implements Validation {
+  async validate(input: any): Promise<Error | undefined> {
+    return undefined;
+  }
+}

--- a/src/data/usecases/validate-parameter.ts
+++ b/src/data/usecases/validate-parameter.ts
@@ -1,7 +1,0 @@
-import { Validation } from '@/domain/usecases';
-
-export class ValidateParameters implements Validation {
-  async validate(input: any): Promise<Error | undefined> {
-    return undefined;
-  }
-}

--- a/src/data/usecases/validate-parameters.ts
+++ b/src/data/usecases/validate-parameters.ts
@@ -1,0 +1,21 @@
+import { ValidateParametersAdapter } from '@/data/protocols';
+import { Validation } from '@/domain/usecases';
+
+export class ValidateParameters implements Validation {
+  private readonly validateParametersAdapter: ValidateParametersAdapter;
+
+  constructor(params: ValidateParameters.Params) {
+    Object.assign(this, params);
+  }
+
+  async validate(input: any): Promise<Error | undefined> {
+    this.validateParametersAdapter.validate(input);
+    return undefined;
+  }
+}
+
+declare namespace ValidateParameters {
+  export type Params = {
+    validateParametersAdapter: ValidateParametersAdapter;
+  };
+}

--- a/src/data/usecases/validate-parameters.ts
+++ b/src/data/usecases/validate-parameters.ts
@@ -1,5 +1,6 @@
 import { ValidateParametersAdapter } from '@/data/protocols';
 import { Validation } from '@/domain/usecases';
+import { ObjectValidationError } from '@/presentation/errors';
 
 export class ValidateParameters implements Validation {
   private readonly validateParametersAdapter: ValidateParametersAdapter;
@@ -9,8 +10,12 @@ export class ValidateParameters implements Validation {
   }
 
   async validate(input: any): Promise<Error | undefined> {
-    this.validateParametersAdapter.validate(input);
-    return undefined;
+    try {
+      await this.validateParametersAdapter.validate(input);
+      return undefined;
+    } catch (error) {
+      return new ObjectValidationError();
+    }
   }
 }
 

--- a/src/data/usecases/validate-parameters.ts
+++ b/src/data/usecases/validate-parameters.ts
@@ -5,13 +5,13 @@ import { ObjectValidationError } from '@/presentation/errors';
 export class ValidateParameters implements Validation {
   private readonly validateParametersAdapter: ValidateParametersAdapter;
 
-  constructor(params: ValidateParameters.Params) {
+  constructor(params: ValidateParameters.ConstructorParams) {
     Object.assign(this, params);
   }
 
-  async validate(input: any): Promise<Error | undefined> {
+  async validate(params: any): Promise<Error | undefined> {
     try {
-      await this.validateParametersAdapter.validate(input);
+      await this.validateParametersAdapter.validate(params);
       return undefined;
     } catch (error) {
       return new ObjectValidationError();
@@ -20,7 +20,7 @@ export class ValidateParameters implements Validation {
 }
 
 declare namespace ValidateParameters {
-  export type Params = {
+  export type ConstructorParams = {
     validateParametersAdapter: ValidateParametersAdapter;
   };
 }

--- a/src/domain/usecases/validation.ts
+++ b/src/domain/usecases/validation.ts
@@ -1,3 +1,3 @@
 export interface Validation {
-  validate: (input: any) => Promise<Error | undefined>;
+  validate: (params: any) => Promise<Error | undefined>;
 }

--- a/src/domain/usecases/validation.ts
+++ b/src/domain/usecases/validation.ts
@@ -1,3 +1,3 @@
 export interface Validation {
-  validate: (input: any) => Error | undefined;
+  validate: (input: any) => Promise<Error | undefined>;
 }

--- a/src/infra/adapter/index.ts
+++ b/src/infra/adapter/index.ts
@@ -1,0 +1,1 @@
+export * from './joi-adapter';

--- a/src/infra/adapter/joi-adapter.ts
+++ b/src/infra/adapter/joi-adapter.ts
@@ -5,17 +5,17 @@ import { ValidateParametersAdapter } from '@/data/protocols';
 export class JoiAdapter implements ValidateParametersAdapter {
   private readonly schema: Schema;
 
-  constructor(params: JoiAdapter.Params) {
+  constructor(params: JoiAdapter.ConstructorParams) {
     Object.assign(this, params);
   }
 
-  async validate(input: any): Promise<void> {
-    await this.schema.validateAsync(input);
+  async validate(params: any): Promise<void> {
+    await this.schema.validateAsync(params);
   }
 }
 
 declare namespace JoiAdapter {
-  export type Params = {
+  export type ConstructorParams = {
     schema: Schema;
   };
 }

--- a/src/infra/adapter/joi-adapter.ts
+++ b/src/infra/adapter/joi-adapter.ts
@@ -1,0 +1,21 @@
+import { Schema } from 'joi';
+
+import { ValidateParametersAdapter } from '@/data/protocols';
+
+export class JoiAdapter implements ValidateParametersAdapter {
+  private readonly schema: Schema;
+
+  constructor(params: JoiAdapter.Params) {
+    Object.assign(this, params);
+  }
+
+  async validate(input: any): Promise<void> {
+    await this.schema.validateAsync(input);
+  }
+}
+
+declare namespace JoiAdapter {
+  export type Params = {
+    schema: Schema;
+  };
+}

--- a/src/main/adapters/express-route-adapter.ts
+++ b/src/main/adapters/express-route-adapter.ts
@@ -2,7 +2,11 @@ import { Request, Response } from 'express';
 
 import { Controller } from '@/presentation/protocols';
 
-export const adaptRoute = (controller: Controller) => {
+export type AdaptRouteParams = {
+  controller: Controller;
+};
+
+export const adaptRoute = ({ controller }: AdaptRouteParams) => {
   return async (req: Request, res: Response) => {
     const request = {
       body: req.body,

--- a/src/main/adapters/express-route-adapter.ts
+++ b/src/main/adapters/express-route-adapter.ts
@@ -9,13 +9,17 @@ export const adaptRoute = (controller: Controller) => {
       params: req.params,
     };
 
-    const httpResponse = await controller.handle(request);
-    if (httpResponse.statusCode >= 200 && httpResponse.statusCode <= 299) {
-      res.status(httpResponse.statusCode).json(httpResponse.body);
-    } else {
-      res.status(httpResponse.statusCode).json({
-        error: httpResponse.body.message,
-      });
+    try {
+      const httpResponse = await controller.handle(request);
+      if (httpResponse.statusCode >= 200 && httpResponse.statusCode <= 299) {
+        res.status(httpResponse.statusCode).json(httpResponse.body);
+      } else {
+        res.status(httpResponse.statusCode).json({
+          error: httpResponse.body.message,
+        });
+      }
+    } catch (error) {
+      res.status(500).json({ message: 'Internal server error.' });
     }
   };
 };

--- a/src/main/config/app.ts
+++ b/src/main/config/app.ts
@@ -1,11 +1,11 @@
 import express, { Express } from 'express';
 
 import setupMiddlewares from '@/main/config/middlewares';
-// import setupRoutes from '@/main/config/routes';
+import setupRoutes from '@/main/config/routes';
 
 export const setupApp = async (): Promise<Express> => {
   const app = express();
   setupMiddlewares(app);
-  // setupRoutes(app);
+  setupRoutes(app);
   return app;
 };

--- a/src/main/config/app.ts
+++ b/src/main/config/app.ts
@@ -5,7 +5,9 @@ import setupRoutes from '@/main/config/routes';
 
 export const setupApp = async (): Promise<Express> => {
   const app = express();
+
   setupMiddlewares(app);
   setupRoutes(app);
+
   return app;
 };

--- a/src/main/factories/controllers/hello-world-controller-factory.ts
+++ b/src/main/factories/controllers/hello-world-controller-factory.ts
@@ -1,0 +1,12 @@
+import Joi from 'joi';
+
+import { HelloWorldController } from '@/presentation/controllers';
+import { makeValidateParameters } from '@/main/factories';
+
+export const makeHelloWorldController = (): HelloWorldController => {
+  const schema = Joi.object({
+    message: Joi.string().required(),
+  });
+
+  return new HelloWorldController({ validation: makeValidateParameters(schema) });
+};

--- a/src/main/factories/controllers/index.ts
+++ b/src/main/factories/controllers/index.ts
@@ -1,0 +1,1 @@
+export * from './hello-world-controller-factory';

--- a/src/main/factories/index.ts
+++ b/src/main/factories/index.ts
@@ -1,0 +1,2 @@
+export * from './controllers';
+export * from './usecases';

--- a/src/main/factories/usecases/index.ts
+++ b/src/main/factories/usecases/index.ts
@@ -1,0 +1,1 @@
+export * from './validate-parameters-factory';

--- a/src/main/factories/usecases/validate-parameters-factory.ts
+++ b/src/main/factories/usecases/validate-parameters-factory.ts
@@ -1,0 +1,10 @@
+import { Schema } from 'joi';
+
+import { ValidateParameters } from '@/data/usecases';
+import { JoiAdapter } from '@/infra/adapter';
+
+export const makeValidateParameters = (schema: Schema): ValidateParameters => {
+  const validateParametersAdapter = new JoiAdapter({ schema });
+
+  return new ValidateParameters({ validateParametersAdapter: validateParametersAdapter });
+};

--- a/src/main/routes/hello-world-routes.ts
+++ b/src/main/routes/hello-world-routes.ts
@@ -1,0 +1,8 @@
+import { Router } from 'express';
+
+import { adaptRoute } from '@/main/adapters';
+import { makeHelloWorldController } from '@/main/factories';
+
+export default (router: Router): void => {
+  router.post('/hello-world', adaptRoute(makeHelloWorldController()));
+};

--- a/src/main/routes/hello-world-routes.ts
+++ b/src/main/routes/hello-world-routes.ts
@@ -4,5 +4,5 @@ import { adaptRoute } from '@/main/adapters';
 import { makeHelloWorldController } from '@/main/factories';
 
 export default (router: Router): void => {
-  router.post('/hello-world', adaptRoute(makeHelloWorldController()));
+  router.post('/hello-world', adaptRoute({ controller: makeHelloWorldController() }));
 };

--- a/src/presentation/controllers/hello-world-controller.ts
+++ b/src/presentation/controllers/hello-world-controller.ts
@@ -1,5 +1,5 @@
 import { Validation } from '@/domain/usecases';
-import { ok } from '@/presentation/helpers';
+import { badRequest, ok } from '@/presentation/helpers';
 import { Controller, HttpResponse } from '@/presentation/protocols';
 
 export class HelloWorldController implements Controller {
@@ -10,7 +10,8 @@ export class HelloWorldController implements Controller {
   }
 
   async handle({ body }: HelloWorldController.Request): Promise<HttpResponse> {
-    this.validation.validate(body);
+    const error = await this.validation.validate(body);
+    if (error) return badRequest(error);
 
     return ok({ message: body.message });
   }

--- a/src/presentation/controllers/hello-world-controller.ts
+++ b/src/presentation/controllers/hello-world-controller.ts
@@ -1,0 +1,16 @@
+import { ok } from '@/presentation/helpers';
+import { Controller, HttpResponse } from '@/presentation/protocols';
+
+export class HelloWorldController implements Controller {
+  async handle({ body }: HelloWorldController.Request): Promise<HttpResponse> {
+    return ok({ message: body.message });
+  }
+}
+
+export namespace HelloWorldController {
+  export type Request = {
+    body: {
+      message: string;
+    };
+  };
+}

--- a/src/presentation/controllers/hello-world-controller.ts
+++ b/src/presentation/controllers/hello-world-controller.ts
@@ -5,11 +5,11 @@ import { Controller, HttpResponse } from '@/presentation/protocols';
 export class HelloWorldController implements Controller {
   private readonly validation: Validation;
 
-  constructor(params: HelloWorldController.Params) {
+  constructor(params: HelloWorldController.ConstructorParams) {
     Object.assign(this, params);
   }
 
-  async handle({ body }: HelloWorldController.Request): Promise<HttpResponse> {
+  async handle({ body }: HelloWorldController.HandleParams): Promise<HttpResponse> {
     const error = await this.validation.validate(body);
     if (error) return badRequest(error);
 
@@ -18,11 +18,11 @@ export class HelloWorldController implements Controller {
 }
 
 export namespace HelloWorldController {
-  export type Params = {
+  export type ConstructorParams = {
     validation: Validation;
   };
 
-  export type Request = {
+  export type HandleParams = {
     body: {
       message: string;
     };

--- a/src/presentation/controllers/hello-world-controller.ts
+++ b/src/presentation/controllers/hello-world-controller.ts
@@ -1,13 +1,26 @@
+import { Validation } from '@/domain/usecases';
 import { ok } from '@/presentation/helpers';
 import { Controller, HttpResponse } from '@/presentation/protocols';
 
 export class HelloWorldController implements Controller {
+  private readonly validation: Validation;
+
+  constructor(params: HelloWorldController.Params) {
+    Object.assign(this, params);
+  }
+
   async handle({ body }: HelloWorldController.Request): Promise<HttpResponse> {
+    this.validation.validate(body);
+
     return ok({ message: body.message });
   }
 }
 
 export namespace HelloWorldController {
+  export type Params = {
+    validation: Validation;
+  };
+
   export type Request = {
     body: {
       message: string;

--- a/src/presentation/controllers/index.ts
+++ b/src/presentation/controllers/index.ts
@@ -1,0 +1,1 @@
+export * from './hello-world-controller';

--- a/tests/data/mocks/index.ts
+++ b/tests/data/mocks/index.ts
@@ -1,0 +1,1 @@
+export * from './mock-validate';

--- a/tests/data/mocks/mock-validate.ts
+++ b/tests/data/mocks/mock-validate.ts
@@ -1,0 +1,9 @@
+import { ValidateParametersAdapter } from '@/data/protocols';
+
+export class ValidateParametersAdapterSpy implements ValidateParametersAdapter {
+  input: any;
+
+  async validate(input: any): Promise<void> {
+    this.input = input;
+  }
+}

--- a/tests/data/mocks/mock-validate.ts
+++ b/tests/data/mocks/mock-validate.ts
@@ -1,9 +1,9 @@
 import { ValidateParametersAdapter } from '@/data/protocols';
 
 export class ValidateParametersAdapterSpy implements ValidateParametersAdapter {
-  input: any;
+  params: any;
 
-  async validate(input: any): Promise<void> {
-    this.input = input;
+  async validate(params: any): Promise<void> {
+    this.params = params;
   }
 }

--- a/tests/data/usecases/validate-parameters.spec.ts
+++ b/tests/data/usecases/validate-parameters.spec.ts
@@ -1,8 +1,10 @@
 import faker from '@faker-js/faker';
 
 import { ValidateParameters } from '@/data/usecases';
+import { ObjectValidationError } from '@/presentation/errors';
 
 import { ValidateParametersAdapterSpy } from '@/tests/data/mocks';
+import { throwError } from '@/tests/domain/mocks';
 
 const mockRequest = (): any => ({
   name: faker.name.firstName(),
@@ -22,6 +24,12 @@ describe('ValidateParameters usecase', () => {
   it('should call ValidateParametersAdapter with correct values', async () => {
     await sut.validate(request);
     expect(validateParametersAdapterSpy.input).toEqual(request);
+  });
+
+  it('should return an ObjectValidationError if ValidationParametersAdapter throws', async () => {
+    jest.spyOn(validateParametersAdapterSpy, 'validate').mockImplementationOnce(throwError);
+    const response = await sut.validate(request);
+    expect(response).toEqual(new ObjectValidationError());
   });
 
   it('should return undefined if there are no errors', async () => {

--- a/tests/data/usecases/validate-parameters.spec.ts
+++ b/tests/data/usecases/validate-parameters.spec.ts
@@ -23,7 +23,7 @@ describe('ValidateParameters usecase', () => {
 
   it('should call ValidateParametersAdapter with correct values', async () => {
     await sut.validate(request);
-    expect(validateParametersAdapterSpy.input).toEqual(request);
+    expect(validateParametersAdapterSpy.params).toEqual(request);
   });
 
   it('should return an ObjectValidationError if ValidationParametersAdapter throws', async () => {

--- a/tests/data/usecases/validate-parameters.spec.ts
+++ b/tests/data/usecases/validate-parameters.spec.ts
@@ -1,0 +1,14 @@
+import { ValidateParameters } from '@/data/usecases/validate-parameter';
+
+describe('ValidateParameters usecase', () => {
+  let sut: ValidateParameters;
+
+  beforeEach(() => {
+    sut = new ValidateParameters();
+  });
+
+  it('should return undefined if there are no errors', async () => {
+    const response = await sut.validate({});
+    expect(response).toBeUndefined();
+  });
+});

--- a/tests/data/usecases/validate-parameters.spec.ts
+++ b/tests/data/usecases/validate-parameters.spec.ts
@@ -1,14 +1,31 @@
-import { ValidateParameters } from '@/data/usecases/validate-parameter';
+import faker from '@faker-js/faker';
+
+import { ValidateParameters } from '@/data/usecases';
+
+import { ValidateParametersAdapterSpy } from '@/tests/data/mocks';
+
+const mockRequest = (): any => ({
+  name: faker.name.firstName(),
+});
 
 describe('ValidateParameters usecase', () => {
+  let validateParametersAdapterSpy: ValidateParametersAdapterSpy;
   let sut: ValidateParameters;
+  let request: any;
 
   beforeEach(() => {
-    sut = new ValidateParameters();
+    validateParametersAdapterSpy = new ValidateParametersAdapterSpy();
+    sut = new ValidateParameters({ validateParametersAdapter: validateParametersAdapterSpy });
+    request = mockRequest();
+  });
+
+  it('should call ValidateParametersAdapter with correct values', async () => {
+    await sut.validate(request);
+    expect(validateParametersAdapterSpy.input).toEqual(request);
   });
 
   it('should return undefined if there are no errors', async () => {
-    const response = await sut.validate({});
+    const response = await sut.validate(request);
     expect(response).toBeUndefined();
   });
 });

--- a/tests/domain/mocks/index.ts
+++ b/tests/domain/mocks/index.ts
@@ -1,0 +1,1 @@
+export * from './mock-validation';

--- a/tests/domain/mocks/index.ts
+++ b/tests/domain/mocks/index.ts
@@ -1,1 +1,2 @@
 export * from './mock-validation';
+export * from './test-helpers';

--- a/tests/domain/mocks/mock-validation.ts
+++ b/tests/domain/mocks/mock-validation.ts
@@ -4,7 +4,7 @@ export class ValidationSpy implements Validation {
   error: Error | undefined;
   input: any;
 
-  validate(input: any): Error | undefined {
+  async validate(input: any): Promise<Error | undefined> {
     this.input = input;
     return this.error;
   }

--- a/tests/domain/mocks/mock-validation.ts
+++ b/tests/domain/mocks/mock-validation.ts
@@ -2,10 +2,10 @@ import { Validation } from '@/domain/usecases';
 
 export class ValidationSpy implements Validation {
   error: Error | undefined;
-  input: any;
+  params: any;
 
-  async validate(input: any): Promise<Error | undefined> {
-    this.input = input;
+  async validate(params: any): Promise<Error | undefined> {
+    this.params = params;
     return this.error;
   }
 }

--- a/tests/domain/mocks/mock-validation.ts
+++ b/tests/domain/mocks/mock-validation.ts
@@ -1,0 +1,11 @@
+import { Validation } from '@/domain/usecases';
+
+export class ValidationSpy implements Validation {
+  error: Error | undefined;
+  input: any;
+
+  validate(input: any): Error | undefined {
+    this.input = input;
+    return this.error;
+  }
+}

--- a/tests/domain/mocks/test-helpers.ts
+++ b/tests/domain/mocks/test-helpers.ts
@@ -1,0 +1,3 @@
+export const throwError = (): never => {
+  throw new Error();
+};

--- a/tests/infra/adapter/joi-adapter.spec.ts
+++ b/tests/infra/adapter/joi-adapter.spec.ts
@@ -1,0 +1,20 @@
+import Joi, { Schema } from 'joi';
+
+import { JoiAdapter } from '@/infra/adapter';
+
+describe('Joi Adapter', () => {
+  let schema: Schema;
+  let sut: JoiAdapter;
+
+  beforeAll(() => {
+    schema = Joi.object({ name: Joi.string().required() });
+    sut = new JoiAdapter({ schema });
+  });
+
+  describe('validate()', () => {
+    it('should reject if input is not valid', async () => {
+      const promise = sut.validate({});
+      await expect(promise).rejects.toThrow();
+    });
+  });
+});

--- a/tests/infra/adapter/joi-adapter.spec.ts
+++ b/tests/infra/adapter/joi-adapter.spec.ts
@@ -1,3 +1,4 @@
+import faker from '@faker-js/faker';
 import Joi, { Schema } from 'joi';
 
 import { JoiAdapter } from '@/infra/adapter';
@@ -15,6 +16,11 @@ describe('Joi Adapter', () => {
     it('should reject if input is not valid', async () => {
       const promise = sut.validate({});
       await expect(promise).rejects.toThrow();
+    });
+
+    it('should return void if input is valid', async () => {
+      const promise = sut.validate({ name: faker.name.firstName() });
+      await expect(promise).resolves.not.toThrow();
     });
   });
 });

--- a/tests/main/routes/hello-world-routes.test.ts
+++ b/tests/main/routes/hello-world-routes.test.ts
@@ -1,0 +1,18 @@
+import { Express } from 'express';
+import request from 'supertest';
+
+import { setupApp } from '@/main/config/app';
+
+describe('HelloWorld Routes', () => {
+  let app: Express;
+
+  beforeAll(async () => {
+    app = await setupApp();
+  });
+
+  describe('POST /hello-world', () => {
+    it('should return 400 if body validation fails', async () => {
+      await request(app).post('/hello-world').send({}).expect(400);
+    });
+  });
+});

--- a/tests/main/routes/hello-world-routes.test.ts
+++ b/tests/main/routes/hello-world-routes.test.ts
@@ -1,3 +1,4 @@
+import faker from '@faker-js/faker';
 import { Express } from 'express';
 import request from 'supertest';
 
@@ -13,6 +14,17 @@ describe('HelloWorld Routes', () => {
   describe('POST /hello-world', () => {
     it('should return 400 if body validation fails', async () => {
       await request(app).post('/hello-world').send({}).expect(400);
+    });
+
+    it('should return 200 with the same message as sent', async () => {
+      const message = faker.random.words();
+      await request(app)
+        .post('/hello-world')
+        .send({
+          message,
+        })
+        .expect(200)
+        .expect({ message });
     });
   });
 });

--- a/tests/presentation/controllers/hello-world-controller.spec.ts
+++ b/tests/presentation/controllers/hello-world-controller.spec.ts
@@ -3,6 +3,8 @@ import faker from '@faker-js/faker';
 import { HelloWorldController } from '@/presentation/controllers';
 import { ok } from '@/presentation/helpers';
 
+import { ValidationSpy } from '@/tests/domain/mocks';
+
 const mockRequest = (): HelloWorldController.Request => ({
   body: {
     message: faker.random.words(5),
@@ -10,12 +12,19 @@ const mockRequest = (): HelloWorldController.Request => ({
 });
 
 describe('HelloWorld Controller', () => {
+  let validationSpy: ValidationSpy;
   let sut: HelloWorldController;
   let request: HelloWorldController.Request;
 
   beforeEach(() => {
-    sut = new HelloWorldController();
+    validationSpy = new ValidationSpy();
+    sut = new HelloWorldController({ validation: validationSpy });
     request = mockRequest();
+  });
+
+  it('should call Validation with correct params', async () => {
+    await sut.handle(request);
+    expect(validationSpy.input).toEqual(request.body);
   });
 
   it('should return 200 with correct body on success', async () => {

--- a/tests/presentation/controllers/hello-world-controller.spec.ts
+++ b/tests/presentation/controllers/hello-world-controller.spec.ts
@@ -1,0 +1,25 @@
+import faker from '@faker-js/faker';
+
+import { HelloWorldController } from '@/presentation/controllers';
+import { ok } from '@/presentation/helpers';
+
+const mockRequest = (): HelloWorldController.Request => ({
+  body: {
+    message: faker.random.words(5),
+  },
+});
+
+describe('HelloWorld Controller', () => {
+  let sut: HelloWorldController;
+  let request: HelloWorldController.Request;
+
+  beforeEach(() => {
+    sut = new HelloWorldController();
+    request = mockRequest();
+  });
+
+  it('should return 200 with correct body on success', async () => {
+    const response = await sut.handle(request);
+    expect(response).toEqual(ok(request.body));
+  });
+});

--- a/tests/presentation/controllers/hello-world-controller.spec.ts
+++ b/tests/presentation/controllers/hello-world-controller.spec.ts
@@ -5,7 +5,7 @@ import { badRequest, ok } from '@/presentation/helpers';
 
 import { throwError, ValidationSpy } from '@/tests/domain/mocks';
 
-const mockRequest = (): HelloWorldController.Request => ({
+const mockRequest = (): HelloWorldController.HandleParams => ({
   body: {
     message: faker.random.words(5),
   },
@@ -14,7 +14,7 @@ const mockRequest = (): HelloWorldController.Request => ({
 describe('HelloWorld Controller', () => {
   let validationSpy: ValidationSpy;
   let sut: HelloWorldController;
-  let request: HelloWorldController.Request;
+  let request: HelloWorldController.HandleParams;
 
   beforeEach(() => {
     validationSpy = new ValidationSpy();
@@ -24,7 +24,7 @@ describe('HelloWorld Controller', () => {
 
   it('should call Validation with correct params', async () => {
     await sut.handle(request);
-    expect(validationSpy.input).toEqual(request.body);
+    expect(validationSpy.params).toEqual(request.body);
   });
 
   it('should return 400 if Validation returns an error', async () => {

--- a/tests/presentation/controllers/hello-world-controller.spec.ts
+++ b/tests/presentation/controllers/hello-world-controller.spec.ts
@@ -1,7 +1,7 @@
 import faker from '@faker-js/faker';
 
 import { HelloWorldController } from '@/presentation/controllers';
-import { ok } from '@/presentation/helpers';
+import { badRequest, ok } from '@/presentation/helpers';
 
 import { ValidationSpy } from '@/tests/domain/mocks';
 
@@ -25,6 +25,12 @@ describe('HelloWorld Controller', () => {
   it('should call Validation with correct params', async () => {
     await sut.handle(request);
     expect(validationSpy.input).toEqual(request.body);
+  });
+
+  it('should return 400 if Validation returns an error', async () => {
+    validationSpy.error = new Error();
+    const response = await sut.handle(request);
+    expect(response).toEqual(badRequest(validationSpy.error));
   });
 
   it('should return 200 with correct body on success', async () => {

--- a/tests/presentation/controllers/hello-world-controller.spec.ts
+++ b/tests/presentation/controllers/hello-world-controller.spec.ts
@@ -3,7 +3,7 @@ import faker from '@faker-js/faker';
 import { HelloWorldController } from '@/presentation/controllers';
 import { badRequest, ok } from '@/presentation/helpers';
 
-import { ValidationSpy } from '@/tests/domain/mocks';
+import { throwError, ValidationSpy } from '@/tests/domain/mocks';
 
 const mockRequest = (): HelloWorldController.Request => ({
   body: {
@@ -31,6 +31,12 @@ describe('HelloWorld Controller', () => {
     validationSpy.error = new Error();
     const response = await sut.handle(request);
     expect(response).toEqual(badRequest(validationSpy.error));
+  });
+
+  it('should throw if Validation throws', async () => {
+    jest.spyOn(validationSpy, 'validate').mockImplementationOnce(throwError);
+    const promise = sut.handle(request);
+    await expect(promise).rejects.toThrow();
   });
 
   it('should return 200 with correct body on success', async () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,7 +29,8 @@
     "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
     "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["src/*"],
+      "@/tests/*": ["tests/*"],
     },                                               /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like `./node_modules/@types`. */


### PR DESCRIPTION
## Description
This feature was created as an example of how to build an endpoint using this template.

## Functionality
The endpoint to call is `[POST] /hello-world` and it requires a `message` parameter as string. In case of `success`, it will simply return the message sent in the response body with a status code 200.

### Fail cases
- `400` - Body validation error;